### PR TITLE
Required according to sample provided in react-native-fbsdk

### DIFF
--- a/RNFacebookExample/android/app/src/main/AndroidManifest.xml
+++ b/RNFacebookExample/android/app/src/main/AndroidManifest.xml
@@ -19,6 +19,12 @@
         <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/facebook_app_id"/>
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+      <!--add FacebookActivity-->
+        <activity
+                android:name="com.facebook.FacebookActivity"
+                android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
+                android:label="@string/app_name"
+                android:theme="@android:style/Theme.Translucent.NoTitleBar"/>
     </application>
 
 </manifest>


### PR DESCRIPTION
Need to add activity which will handle opening app dialog for oauth otherwise crash is observed

`05-06 10:50:28.788: E/AndroidRuntime(3325): Log in attempt failed: FacebookActivity could not be started. Please make sure you added FacebookActivity to the AndroidManifest.
05-06 10:50:28.788: E/AndroidRuntime(3325):     at com.facebook.login.LoginManager.startLogin(LoginManager.java:441)
05-06 10:50:28.788: E/AndroidRuntime(3325):     at com.facebook.login.LoginManager.logInWithPublishPermissions(LoginManager.java:359)
05-06 10:50:28.788: E/AndroidRuntime(3325):     at com.facebook.login.widget.LoginButton$LoginClickListener.performLogin(LoginButton.java:724)
05-06 10:50:28.788: E/AndroidRuntime(3325):     at com.facebook.login.widget.LoginButton$LoginClickListener.onClick(LoginButton.java:701)
05-06 10:50:28.788: E/AndroidRuntime(3325):     at com.facebook.FacebookButtonBase$1.onClick(FacebookButtonBase.java:385)
05-06 10:56:25.132: W/com.facebook.internal.Validate(3396): FacebookActivity is not declared in the AndroidManifest.xml, please add com.facebook.FacebookActivity to your AndroidManifest.xml file. See https://developers.facebook.com/docs/android/getting-started for more info.
`
